### PR TITLE
Add submission date to email subject

### DIFF
--- a/Submitter.cpp
+++ b/Submitter.cpp
@@ -991,7 +991,7 @@ namespace sict {
          if (m_skipSpaces && m_skipNewlines) email += " - ";
          if (m_skipNewlines) email += " lines";
       }
-      email += " submission by `whoami`\" ";
+      email += " submission by `whoami` at `date +'%Y-%m-%d %r'`\" ";
       email += " -Sreplyto=`whoami`@myseneca.ca ";
       if (!Confirmation || cc_files_to_students) {
          for (int i = 0; i < m_asVals["submit_files"].size(); i++) {


### PR DESCRIPTION
Proposing we add submission date to the email subject line, probably because of my specific situation (where I am unable to verify the submission date other than asking 
 people to forward the submission email to me which has the timezone & time based on their email provider locale).
Thought this might be useful in general though.

Please feel free to decline merge if it's not needed or propose changes. Thank you!